### PR TITLE
Fancy features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+*code-workspace
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-*code-workspace
+*.code-workspace
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode
 *.code-workspace
 
 # Byte-compiled / optimized / DLL files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "*.yaml": "home-assistant"
-    }
-}

--- a/example_system_sensors.service
+++ b/example_system_sensors.service
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 User=pi
 Type=idle
-ExecStart=/usr/bin/python3 ~/system_sensors/src/system_sensors.py ~/system_sensors/src/settings.yaml
+ExecStart=/usr/bin/python3 /home/pi/system_sensors/src/system_sensors.py /home/pi/system_sensors/src/settings.yaml
 
 [Install]
 WantedBy=multi-user.target

--- a/example_system_sensors.service
+++ b/example_system_sensors.service
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 User=pi
 Type=idle
-ExecStart=/usr/bin/python3 /home/pi/system_sensors/src/system_sensors.py /home/pi/system_sensors/src/settings.yaml
+ExecStart=/usr/bin/python3 /home/pi/system_sensors/src/system_sensors.py --settings /home/pi/system_sensors/src/settings.yaml
 
 [Install]
 WantedBy=multi-user.target

--- a/example_system_sensors.service
+++ b/example_system_sensors.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=System Sensor service
+Description=System Sensor
 After=multi-user.target
 
 [Service]
-User=gughan
+User=pi
 Type=idle
-ExecStart=/usr/bin/python3 /home/gughan/system_sensors/src/system_sensors.py /home/gughan/system_sensors/src/settings.yaml
+ExecStart=/usr/bin/python3 ~/system_sensors/src/system_sensors.py ~/system_sensors/src/settings.yaml
 
 [Install]
 WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ psutil==5.6.6
 pytz==2019.2
 PyYAML==5.4
 rpi_bad_power==0.1.0
+schedule

--- a/src/c_print.py
+++ b/src/c_print.py
@@ -6,21 +6,24 @@ class text_color:
     OK = '\033[0;32;48m' #GREEN
     WARNING = '\033[0;33;48m' #YELLOW
     FAIL = '\033[0;31;48m' #RED
-    WHITE = '\033[0;37;48m' #WHITE
+    HLIGHT = '\033[0;37;48m' #WHITE
+    NOTICE = '\033[0;34;48m' #BLUE
     DARK = '\033[0;30;48m' #DARK GREY
     # Coloured BG
     C_OK = '\033[0;37;42m' #GREEN
     C_WARNING = '\033[0;37;43m' #YELLOW
     C_FAIL = '\033[0;37;41m' #RED
-    C_BLACK = '\033[0;30;47m' #BLACK
+    C_HLIGHT = '\033[0;30;47m' #WHITE
+    C_NOTICE = '\033[0;37;44m' #BLUE
     # Bright
     B_OK = '\033[1;32;48m' #GREEN
     B_WARNING = '\033[1;33;48m' #YELLOW
     B_FAIL = '\033[1;31;48m' #RED
-    B_WHITE = '\033[1;37;48m' #WHITE
+    B_HLIGHT = '\033[1;37;48m' #WHITE
+    B_NOTICE = '\033[1;34;48m' #BLUE
     B_DARK = '\033[1;30;48m' #DARK GREY
 
-def write_message_to_console(message = '', **kwargs):
+def c_print(message = '', **kwargs):
     if message is None or message == '':
         print()
     else:    
@@ -30,7 +33,9 @@ def write_message_to_console(message = '', **kwargs):
                 dressing = f'    {dressing}'
         if 'status' in kwargs and type(kwargs['status']) is not None:
             if kwargs['status'] == 'info':
-                dressing = f'{dressing}{text_color.B_DARK}[{text_color.B_WHITE}i{text_color.B_DARK}]{text_color.RESET} '
+                dressing = f'{dressing}{text_color.B_DARK}[{text_color.B_HLIGHT}i{text_color.B_DARK}]{text_color.RESET} '
+            if kwargs['status'] == 'wait':
+                dressing = f'{dressing}{text_color.B_DARK}[{text_color.B_HLIGHT}•{text_color.B_DARK}]{text_color.RESET} '
             elif kwargs['status'] == 'ok':
                 dressing = f'{dressing}{text_color.B_DARK}[{text_color.B_OK}✓{text_color.B_DARK}]{text_color.RESET} '
             elif kwargs['status'] == 'warning':
@@ -38,6 +43,6 @@ def write_message_to_console(message = '', **kwargs):
             elif kwargs['status'] == 'fail':
                 dressing = f'{dressing}{text_color.B_DARK}[{text_color.B_FAIL}✗{text_color.B_DARK}]{text_color.RESET} '
         else:
-            dressing = f'{dressing}{text_color.WHITE}'
+            dressing = f'{dressing}{text_color.HLIGHT}'
         print(f'{dressing}{message}{text_color.RESET}')
     stdout.flush()

--- a/src/console_colours.py
+++ b/src/console_colours.py
@@ -1,0 +1,43 @@
+from sys import stdout
+
+class text_color:
+    RESET = '\033[0m' #LIGHT GREY
+    # Normal
+    OK = '\033[0;32;48m' #GREEN
+    WARNING = '\033[0;33;48m' #YELLOW
+    FAIL = '\033[0;31;48m' #RED
+    WHITE = '\033[0;37;48m' #WHITE
+    DARK = '\033[0;30;48m' #DARK GREY
+    # Coloured BG
+    C_OK = '\033[0;37;42m' #GREEN
+    C_WARNING = '\033[0;37;43m' #YELLOW
+    C_FAIL = '\033[0;37;41m' #RED
+    C_BLACK = '\033[0;30;47m' #BLACK
+    # Bright
+    B_OK = '\033[1;32;48m' #GREEN
+    B_WARNING = '\033[1;33;48m' #YELLOW
+    B_FAIL = '\033[1;31;48m' #RED
+    B_WHITE = '\033[1;37;48m' #WHITE
+    B_DARK = '\033[1;30;48m' #DARK GREY
+
+def write_message_to_console(message = '', **kwargs):
+    if message is None or message == '':
+        print()
+    else:    
+        dressing = ''
+        if 'tab' in kwargs and type(kwargs['tab']) == int:
+            for x in range(kwargs['tab']):
+                dressing = f'    {dressing}'
+        if 'status' in kwargs and type(kwargs['status']) is not None:
+            if kwargs['status'] == 'info':
+                dressing = f'{dressing}{text_color.B_DARK}[{text_color.B_WHITE}i{text_color.B_DARK}]{text_color.RESET} '
+            elif kwargs['status'] == 'ok':
+                dressing = f'{dressing}{text_color.B_DARK}[{text_color.B_OK}✓{text_color.B_DARK}]{text_color.RESET} '
+            elif kwargs['status'] == 'warning':
+                dressing = f'{dressing}{text_color.B_DARK}[{text_color.B_WARNING}!{text_color.B_DARK}]{text_color.RESET} '
+            elif kwargs['status'] == 'fail':
+                dressing = f'{dressing}{text_color.B_DARK}[{text_color.B_FAIL}✗{text_color.B_DARK}]{text_color.RESET} '
+        else:
+            dressing = f'{dressing}{text_color.WHITE}'
+        print(f'{dressing}{message}{text_color.RESET}')
+    stdout.flush()

--- a/src/sensors.py
+++ b/src/sensors.py
@@ -1,86 +1,74 @@
 #!/usr/bin/env python3
 
-import re
-import time
-import pytz
-import psutil
-import socket
-import platform
-import subprocess
-import datetime as dt
-import sys
-
-# Only needed if using alternate method of obtaining CPU temperature (see commented out code for approach)
-#from os import walk
-
+import time, pytz, psutil, socket, platform, subprocess
+from datetime import datetime as dt, timedelta as td
+from console_colours import *
 
 rpi_power_disabled = True
+under_voltage = None
+apt_disabled = True
+
+_os_data = {}
+_previous_net_data = psutil.net_io_counters()
+_previous_time = time.time() - 10
+_default_timezone = None
+_utc = pytz.utc
+
+# Test for Raspberry PI power module
 try:
     from rpi_bad_power import new_under_voltage
     if new_under_voltage() is not None:
         # Only enable if import works and function returns a value
         rpi_power_disabled = False
+        under_voltage = new_under_voltage()
 except ImportError:
     pass
 
+# Test for APT module
 try:
     import apt
     apt_disabled = False
 except ImportError:
-    apt_disabled = True
-
+    pass
 
 # Get OS information
-OS_DATA = {}
 with open('/etc/os-release') as f:
     for line in f.readlines():
         row = line.strip().split("=")
-        OS_DATA[row[0]] = row[1].strip('"')
+        _os_data[row[0]] = row[1].strip('"')
 
-old_net_data = psutil.net_io_counters()
-previous_time = time.time() - 10
-UTC = pytz.utc
-DEFAULT_TIME_ZONE = None
+def set_default_timezone(timezone) -> None:
+    global _default_timezone
+    _default_timezone = timezone
 
-if not rpi_power_disabled:
-    _underVoltage = new_under_voltage()
-
-def set_default_timezone(timezone):
-    global DEFAULT_TIME_ZONE
-    DEFAULT_TIME_ZONE = timezone
-
-def write_message_to_console(message):
-    print(message)
-    sys.stdout.flush()
-
-def as_local(dattim: dt.datetime) -> dt.datetime:
-    global DEFAULT_TIME_ZONE
+def as_local(dattim: dt) -> dt:
+    global _default_timezone
     """Convert a UTC datetime object to local time zone."""
-    if dattim.tzinfo == DEFAULT_TIME_ZONE:
+    if dattim.tzinfo == _default_timezone:
         return dattim
     if dattim.tzinfo is None:
-        dattim = UTC.localize(dattim)
+        dattim = _utc.localize(dattim)
 
-    return dattim.astimezone(DEFAULT_TIME_ZONE)
+    return dattim.astimezone(_default_timezone)
 
-def utc_from_timestamp(timestamp: float) -> dt.datetime:
+def utc_from_timestamp(timestamp: float) -> dt:
     """Return a UTC time from a timestamp."""
-    return UTC.localize(dt.datetime.utcfromtimestamp(timestamp))
+    return _utc.localize(dt.utcfromtimestamp(timestamp))
 
-def get_last_boot():
+def get_last_boot() -> str:
     return str(as_local(utc_from_timestamp(psutil.boot_time())).isoformat())
 
-def get_last_message():
+def get_last_message() -> str:
     return str(as_local(utc_from_timestamp(time.time())).isoformat())
 
-def get_updates():
+def get_updates() -> int:
     cache = apt.Cache()
     cache.open(None)
     cache.upgrade()
-    return str(cache.get_changes().__len__())
+    return cache.get_changes().__len__()
 
 # Temperature method depending on system distro
-def get_temp():
+def get_temp() -> float:
     temp = 'Unknown'
     # Utilising psutil for temp reading on ARM arch
     try:
@@ -90,65 +78,49 @@ def get_temp():
             # Assumes that first entry is the CPU package, have not tested this on other systems except my NUC x86
             temp = psutil.sensors_temperatures()['coretemp'][0].current
         except Exception as e:
-            print('Could not establish CPU temperature reading: ' + str(e))
+            write_message_to_console(f'Could not establish CPU temperature reading: {text_color.B_FAIL}{e}', tab=1, status='warning')
             raise
     return round(temp, 1)
 
-            # Option to use thermal_zone readings instead of psutil
-
-            # base_dir = '/sys/class/thermal/'
-            # zone_dir = ''
-            # print('Could not cpu_thermal property. Checking thermal zone for x86 architecture')
-            # for root, dir, files in walk(base_dir):
-            #     for d in dir:
-            #         if 'thermal_zone' in d:
-            #             temp_type = str(subprocess.check_output(['cat', base_dir + d + '/type']).decode('UTF-8'))
-            #             if 'x86' in temp_type:
-            #                 zone_dir = d
-            #                 break
-            # temp = str(int(subprocess.check_output(['cat', base_dir + zone_dir + '/temp']).decode('UTF-8')) / 1000)
-
-
-# Replaced with psutil method - does this not work fine?
-def get_clock_speed():
+def get_clock_speed() -> int:
     clock_speed = int(psutil.cpu_freq().current)
     return clock_speed
 
-def get_disk_usage(path):
+def get_disk_usage(path) -> float:
     try:
-        disk_percentage = str(psutil.disk_usage(path).percent)
+        disk_percentage = psutil.disk_usage(path).percent
         return disk_percentage
     except Exception as e:
-        print('Error while trying to obtain disk usage from ' + str(path) + ' with exception: ' + str(e))
-        return None # Changed to return None for handling exception at function call location
+        write_message_to_console(f'Could not get disk usage from {text_color.B_WHITE}{path}{text_color.RESET}: {text_color.B_FAIL}{e}', tab=1, status='warning')
+        raise
 
-def get_memory_usage():
+def get_memory_usage() -> float:
     return str(psutil.virtual_memory().percent)
 
-def get_load(arg):
+def get_load(arg) -> float:
     return str(psutil.getloadavg()[arg])
 
-def get_net_data(arg):
-    global old_net_data
-    global previous_time
+def get_net_data(arg) -> float:
+    global _previous_net_data
+    global _previous_time
     current_net_data = psutil.net_io_counters()
     current_time = time.time()
-    if current_time == previous_time:
+    if current_time == _previous_time:
         current_time += 1
-    net_data = (current_net_data[0] - old_net_data[0]) / (current_time - previous_time) * 8 / 1024
-    net_data = (net_data, (current_net_data[1] - old_net_data[1]) / (current_time - previous_time) * 8 / 1024)
-    previous_time = current_time
-    old_net_data = current_net_data
+    net_data = (current_net_data[0] - _previous_net_data[0]) / (current_time - _previous_time) * 8 / 1024
+    net_data = (net_data, (current_net_data[1] - _previous_net_data[1]) / (current_time - _previous_time) * 8 / 1024)
+    _previous_time = current_time
+    _previous_net_data = current_net_data
     net_data = ['%.2f' % net_data[0], '%.2f' % net_data[1]]
     return net_data[arg]
 
-def get_cpu_usage():
+def get_cpu_usage() -> float:
     return str(psutil.cpu_percent(interval=None))
 
-def get_swap_usage():
+def get_swap_usage() -> float:
     return str(psutil.swap_memory().percent)
 
-def get_wifi_strength():  # subprocess.check_output(['/proc/net/wireless', 'grep wlan0'])
+def get_wifi_strength() -> int:
     wifi_strength_value = subprocess.check_output(
                               [
                                   'bash',
@@ -160,7 +132,8 @@ def get_wifi_strength():  # subprocess.check_output(['/proc/net/wireless', 'grep
         wifi_strength_value = '0'
     return (wifi_strength_value)
 
-def get_wifi_ssid():
+def get_wifi_ssid() -> str:
+    ssid = 'UNKNOWN'
     try:
         ssid = subprocess.check_output(
                                   [
@@ -169,19 +142,20 @@ def get_wifi_ssid():
                                       '/usr/sbin/iwgetid -r',
                                   ]
                               ).decode('utf-8').rstrip()
-    except subprocess.CalledProcessError:
-        ssid = 'UNKNOWN'
-    if not ssid:
-        ssid = 'UNKNOWN'
-    return (ssid)
+        print(ssid)
+    except Exception as e:
+        write_message_to_console(f'Could not deterine WiFi SSID: {text_color.B_FAIL}{e}', tab=1, status='warning')
+    
+    print(ssid)
+    return ssid
 
-def get_rpi_power_status():
-    return _underVoltage.get()
+def get_rpi_power_status() -> str:
+    return under_voltage.get()
 
-def get_hostname():
+def get_hostname() -> str:
     return socket.gethostname()
 
-def get_host_ip():
+def get_host_ip() -> str:
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.connect(('8.8.8.8', 80))
@@ -194,19 +168,28 @@ def get_host_ip():
     finally:
         sock.close()
 
-def get_host_os():
+def get_host_os() -> str:
     try:
-        return OS_DATA['PRETTY_NAME']
+        return _os_data['PRETTY_NAME']
     except:
         return 'Unknown'
 
-def get_host_arch():
+def get_host_arch() -> str:
     try:
         return platform.machine()
     except:
         return 'Unknown'
 
-sensors = {
+def external_drive_base(drive, drive_path) -> dict:
+    return {
+        'name': f'Disk Use {drive}',
+        'unit': '%',
+        'icon': 'harddisk',
+        'sensor_type': 'sensor',
+        'function': lambda: get_disk_usage(f'{drive_path}')
+        }
+
+sensor_objects = {
           'temperature': 
                 {'name':'Temperature',
                  'class': 'temperature',

--- a/src/settings_example.yaml
+++ b/src/settings_example.yaml
@@ -1,12 +1,13 @@
 mqtt:
-  hostname: 127.0.0.1
-  port: 1883 #defaults to 1883
-  user: test
-  password: test
-deviceName: test
-client_id: test
-timezone: Europe/Brussels
-update_interval: 60 #Defaults to 60
+  hostname: 127.0.0.1       # MQTT broker address (required)
+  port: 1883                # MQTT broker port (defaults to 1883)
+  user: username            # Username for MQTT credentials (required)
+  password: secret          # Username for MQTT credentials (required)
+  connection_retry: 10      # Seconds between reconnection attempts if disconnected (default 10)
+deviceName: Example Client  # Pretty/display name sent with this MQTT topic (required)
+client_id: example_client   # Client ID/name of this device for the MQTT broker (required)
+timezone: Europe/Brussels   # The system's local timezone (required)
+update_interval: 60         # Seconds between updating sensor values and publishing to broker (default 60)
 sensors:
   temperature: true
   clock_speed: true
@@ -25,10 +26,11 @@ sensors:
   host_ip: true
   host_os: true
   host_arch: true
+  hardware_make: true
+  hardware_model: true
   last_message: true
   updates: true
   wifi_strength: true
   wifi_ssid: true
-  external_drives:
-    # Only add mounted drives here, e.g.:
+  external_drives: # Only add mounted drives here, e.g.:
     # Drive1: /media/storage

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,5 @@
+import subprocess
+
+def quick_cat(arg):
+    output = subprocess.run(['cat', arg], capture_output=True)
+    return output.stdout.decode('utf-8').rstrip() if output.returncode == 0 else None

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+wget https://raw.githubusercontent.com/MaxVRAM/system_sensors/master/src/sensors.py -O src/sensors.py
+wget https://raw.githubusercontent.com/MaxVRAM/system_sensors/master/src/system_sensors.py -O src/system_sensors.py
+wget https://raw.githubusercontent.com/MaxVRAM/system_sensors/master/src/console_colours.py -O src/console_colours.py

--- a/update.sh
+++ b/update.sh
@@ -2,4 +2,5 @@
 
 wget https://raw.githubusercontent.com/MaxVRAM/system_sensors/master/src/sensors.py -O src/sensors.py
 wget https://raw.githubusercontent.com/MaxVRAM/system_sensors/master/src/system_sensors.py -O src/system_sensors.py
-wget https://raw.githubusercontent.com/MaxVRAM/system_sensors/master/src/console_colours.py -O src/console_colours.py
+wget https://raw.githubusercontent.com/MaxVRAM/system_sensors/master/src/c_print.py -O src/c_print.py
+wget https://raw.githubusercontent.com/MaxVRAM/system_sensors/master/src/utils.py -O src/utils.py


### PR DESCRIPTION
Merging a bunch of feature additions and fixes from fancy-branch.

Additions:
- Pretty console log formatting
- More verbose/detailed log entries
- 2 new sensors: make and model
- Very basic `update.sh` script
- Connection retry timer setting

Changes:
- Replaced threaded updates & time.sleep() with a task scheduler
- Massive tidy up of print methods (moved all to f strings)
- Sensor function outputs are now type-cast
- `settings.yaml` example updated with new entries and tidied up
- Variable name changes to aid code readability

Fixes:
- MQTT broker now re-connects after disconnection
- Multiple drives now report correct usage values
- Default system_sensor.service file updated with the new `--settings <file.yaml>` argument format (thanks @PepegaBruh)
- Fixed several exceptions